### PR TITLE
Add commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
A deliberately wrong commit message (`Add commitlint`) [fails](https://github.com/nick-f/t/actions/runs/3851363406/jobs/6562451409#step:4:12), as expected.

A commit matching the expected format (`ci: add commitlint`) [passes](https://github.com/nick-f/t/actions/runs/3851378855/jobs/6562480003#step:4:10).