### PR TITLE
Attach to session if not already in tmux

### DIFF
--- a/t.bash
+++ b/t.bash
@@ -83,4 +83,8 @@ if ! tmux has-session -t="$dirname" 2> /dev/null; then
 	tmux new-session -c "$selected" -ds "$dirname"
 fi
 
-tmux switch-client -t "$dirname"
+if [[ -z $TMUX ]]; then
+	tmux attach-session -t "$dirname"
+else
+	tmux switch-client -t "$dirname"
+fi


### PR DESCRIPTION
Previously a `no current client` error would occur when attempting to switch-client if you weren't already in tmux. A check has now been added to attach if that is the case.