### PR TITLE
Only attempt to add dir to path if the dir exists

### DIFF
--- a/t.bash
+++ b/t.bash
@@ -42,9 +42,10 @@ search_path() {
 		path=${path::path_length-1}
 	fi
 
-	local paths; paths=$(find "$path" -maxdepth 1 -mindepth 1 -type d | sed 's#/Users/[a-zA-Z0-9]*/#~/#g' | sort --ignore-case)
-
-	echo -e "\n$paths"
+	if [ -d "$path" ]; then
+		local paths; paths=$(find "$path" -maxdepth 1 -mindepth 1 -type d | sed 's#/Users/[a-zA-Z0-9]*/#~/#g' | sort --ignore-case)
+		echo -e "\n$paths"
+	fi
 }
 
 expand_path() {


### PR DESCRIPTION
Previously, if there was a directory included in the $T_PATHS environment variable that didn't exist, an error would be shown when running `t`.

```
❯ t
find: /Users/nickf/doesnotexist: No such file or directory
```

Now only directories that exist are searched for descendant directories to include in the output list of candidates.